### PR TITLE
Added "Let's just agree to disagree"

### DIFF
--- a/expressions.md
+++ b/expressions.md
@@ -54,6 +54,9 @@
 * "white knighting"
     * Used to disparage someone who stands up against the abusive language of others.
 
+* "Let's just agree to disagree"
+    * "I don't want to learn anything from your perspective, and I don't want to substantiate my own claims, so I'm ending further discussion now."
+     
 # Random idea scraps
 
 Some things that people say can be well-meaning, or they can be


### PR DESCRIPTION
Added "Let's just agree to disagree" to the jerk phrase list. I've heard this one from a couple of different people now, both in work and personal life, usually due to discussions over problems caused directly by belief systems that have no factual basis. It's a thought-terminating cliche that just really just leaves the core problems unresolved and lingering.

I really appreciate the other list entries, and I'm trying to eliminate them all from my own vocabulary, so I wanted to share this one with everyone too.
